### PR TITLE
Update import_blocks.py

### DIFF
--- a/chapter_5/import_blocks.py
+++ b/chapter_5/import_blocks.py
@@ -36,7 +36,7 @@ for block in range(0, 24):
         gas_used = block_data[10]['gas_used'][0]['text']
         timestamp = blocks[block]['result']['timestamp']
         block_doc = {
-            'timestamp': timestamp,
+            'timestamp': datetime.datetime.fromtimestamp(float(timestamp)/1000),
             'block_height': int(block_height),
             'number_transactions': int(number_tx[0]),
             'number_internal_transactions': int(number_tx[3]),


### PR DESCRIPTION
Fixed timestamp issue. This issue caused the `active_day_of_week_transactions` & `active_day_of_week_values` methods of `BlockAggregation` class in `chapter5\block_aggregations.py` to fail due to the fact that timestamps where stored as `long` instead of `Date` in the documents (`mongo_book` db, `blocks` collection)